### PR TITLE
ダイスシステムの型安全性とパフォーマンス改善

### DIFF
--- a/src/application/use-cases/dice/RollDiceUseCase.ts
+++ b/src/application/use-cases/dice/RollDiceUseCase.ts
@@ -68,7 +68,8 @@ export class RollDiceUseCase {
         
         // 故障判定の場合（型安全なアクセス）
         const breakdownNumber = roll.getBreakdownNumber();
-        if (typeof breakdownNumber === 'number') {
+        if (breakdownNumber !== undefined) {
+            // 故障ナンバーが設定されている場合の処理
             if (roll.getTotal() >= breakdownNumber) {
                 if (roll.isCriticalFailure()) {
                     result += `＞ **ファンブル＆故障** `;

--- a/src/application/use-cases/dice/RollDiceUseCase.ts
+++ b/src/application/use-cases/dice/RollDiceUseCase.ts
@@ -4,7 +4,7 @@ import { DiceRollRequest, DiceRollResponse, DiceRollDto } from '../../dto/DiceRo
 import { CCBRoll, ChoiceRoll } from '../../../domain/entities/DiceRoll';
 import { CoCDiceRoll, FARRoll } from '../../../domain/entities/CoCDiceRoll';
 import { convertFullWidthToHalfWidth } from '../../../shared/utils/stringUtils';
-import { DiceRollResult, isDiceRoll, isCoCDiceRoll, isFARRoll } from './types/DiceRollTypes';
+import { DiceRollResult, isDiceRoll, isCoCDiceRoll, isFARRoll, isCCBRoll, isBreakdownAwareCCBRoll } from './types/DiceRollTypes';
 
 export class RollDiceUseCase {
     constructor(private readonly diceService: DiceService) {}
@@ -50,15 +50,24 @@ export class RollDiceUseCase {
             return this.mapFARToDto(roll);
         }
         
+        if (isCCBRoll(roll)) {
+            return this.mapCCBToDto(roll);
+        }
+        
         return this.mapStandardToDto(roll);
     }
 
+    /**
+     * CCBRoll（6版）を型安全にDTOに変換
+     * @param roll CCBRollインスタンス
+     * @returns DiceRollDto
+     */
     private mapCCBToDto(roll: CCBRoll): DiceRollDto {
         let result = `＞ **${roll.getTotal()}** `;
         let color = 0x888888;
         
-        // 故障判定の場合（CCBRollの拡張プロパティ）
-        const breakdownNumber = 'breakdownNumber' in roll ? (roll as any).breakdownNumber : undefined;
+        // 故障判定の場合（型安全なアクセス）
+        const breakdownNumber = roll.getBreakdownNumber();
         if (typeof breakdownNumber === 'number') {
             if (roll.getTotal() >= breakdownNumber) {
                 if (roll.isCriticalFailure()) {

--- a/src/application/use-cases/dice/types/DiceRollTypes.ts
+++ b/src/application/use-cases/dice/types/DiceRollTypes.ts
@@ -25,10 +25,14 @@ export function isCCBRoll(roll: DiceRollResult): roll is CCBRoll {
 }
 
 /**
- * 故障ナンバーを持つCCBRollの型ガード
+ * 故障ナンバーが実際に設定されているCCBRollの型ガード
  * @param roll ダイスロール結果
- * @returns 故障ナンバーを持つCCBRollかどうか
+ * @returns 故障ナンバーが設定されているCCBRollかどうか
  */
-export function isBreakdownAwareCCBRoll(roll: DiceRollResult): roll is CCBRoll & { getBreakdownNumber(): number | undefined } {
-    return roll instanceof CCBRoll && typeof (roll as CCBRoll).getBreakdownNumber === 'function';
+export function isBreakdownAwareCCBRoll(
+    roll: DiceRollResult
+): roll is CCBRoll & { getBreakdownNumber(): number } {
+    if (!(roll instanceof CCBRoll)) return false;
+    const breakdownNumber = roll.getBreakdownNumber();
+    return typeof breakdownNumber === 'number';
 }

--- a/src/application/use-cases/dice/types/DiceRollTypes.ts
+++ b/src/application/use-cases/dice/types/DiceRollTypes.ts
@@ -1,10 +1,10 @@
-import { DiceRoll } from '../../../../domain/entities/DiceRoll';
+import { DiceRoll, CCBRoll } from '../../../../domain/entities/DiceRoll';
 import { CoCDiceRoll, FARRoll } from '../../../../domain/entities/CoCDiceRoll';
 
-export type DiceRollResult = DiceRoll | CoCDiceRoll | FARRoll;
+export type DiceRollResult = DiceRoll | CoCDiceRoll | FARRoll | CCBRoll;
 
 export function isDiceRoll(roll: DiceRollResult): roll is DiceRoll {
-    return roll instanceof DiceRoll && !(roll instanceof CoCDiceRoll) && !(roll instanceof FARRoll);
+    return roll instanceof DiceRoll && !(roll instanceof CoCDiceRoll) && !(roll instanceof FARRoll) && !(roll instanceof CCBRoll);
 }
 
 export function isCoCDiceRoll(roll: DiceRollResult): roll is CoCDiceRoll {
@@ -13,4 +13,22 @@ export function isCoCDiceRoll(roll: DiceRollResult): roll is CoCDiceRoll {
 
 export function isFARRoll(roll: DiceRollResult): roll is FARRoll {
     return roll instanceof FARRoll;
+}
+
+/**
+ * CCBRoll（故障ナンバー付きロール）の型ガード
+ * @param roll ダイスロール結果
+ * @returns CCBRollかどうか
+ */
+export function isCCBRoll(roll: DiceRollResult): roll is CCBRoll {
+    return roll instanceof CCBRoll;
+}
+
+/**
+ * 故障ナンバーを持つCCBRollの型ガード
+ * @param roll ダイスロール結果
+ * @returns 故障ナンバーを持つCCBRollかどうか
+ */
+export function isBreakdownAwareCCBRoll(roll: DiceRollResult): roll is CCBRoll & { getBreakdownNumber(): number | undefined } {
+    return roll instanceof CCBRoll && typeof (roll as CCBRoll).getBreakdownNumber === 'function';
 }

--- a/src/domain/entities/DiceRoll.ts
+++ b/src/domain/entities/DiceRoll.ts
@@ -89,7 +89,8 @@ export class CCBRoll extends DiceRoll {
             isSuccess,
             isSpecial && isSuccess,
             isCritical && isSuccess,
-            isFumble && !isSuccess
+            isFumble && !isSuccess,
+            undefined // 通常のCCBロールには故障ナンバーなし
         );
     }
 }

--- a/src/domain/entities/DiceRoll.ts
+++ b/src/domain/entities/DiceRoll.ts
@@ -41,7 +41,8 @@ export class CCBRoll extends DiceRoll {
         private readonly success: boolean,
         private readonly special: boolean,
         private readonly critical: boolean,
-        private readonly fumble: boolean
+        private readonly fumble: boolean,
+        private readonly breakdownNumber?: number
     ) {
         super(expression, rolls, total, expression);
     }
@@ -64,6 +65,14 @@ export class CCBRoll extends DiceRoll {
 
     isCriticalFailure(): boolean {
         return this.fumble;
+    }
+
+    /**
+     * 故障ナンバーを取得
+     * @returns 故障ナンバー（設定されている場合）
+     */
+    getBreakdownNumber(): number | undefined {
+        return this.breakdownNumber;
     }
 
     static evaluate(target: number, roll: number, ruleType: 'cc' | 'ccb' = 'ccb'): CCBRoll {

--- a/src/domain/services/DiceService.ts
+++ b/src/domain/services/DiceService.ts
@@ -7,10 +7,10 @@ export { IDiceService } from './dice/IDiceService';
 
 /**
  * レガシー互換性のためのDiceServiceクラス
- * 新しい実装は DiceServiceFactory を使用
+ * 新しい実装は DiceServiceFactory を使用（シングルトンパターン）
  */
 export class DiceService implements IDiceService {
-    private diceServiceFactory = new DiceServiceFactory();
+    private diceServiceFactory = DiceServiceFactory.getInstance();
 
     roll(expression: DiceExpression): DiceRoll {
         return this.diceServiceFactory.roll(expression);

--- a/src/domain/services/__tests__/DiceService.test.ts
+++ b/src/domain/services/__tests__/DiceService.test.ts
@@ -67,7 +67,7 @@ describe('DiceService', () => {
             expect(result).toBeInstanceOf(CCBRoll);
             if (result instanceof CCBRoll) {
                 const roll = result.getTotal();
-                const breakdownNumber = (result as any).breakdownNumber;
+                const breakdownNumber = result.getBreakdownNumber();
                 
                 expect(breakdownNumber).toBe(96);
                 

--- a/src/domain/services/dice/CoCDiceService.ts
+++ b/src/domain/services/dice/CoCDiceService.ts
@@ -13,11 +13,23 @@ export class CoCDiceService {
             const target = breakdownMatch[2] ? parseInt(breakdownMatch[2]) : 100;
             const roll = rollDice(1, 100)[0];
             
-            // 故障判定用のCCBRollを作成
-            const ccbRoll = CCBRoll.evaluate(target, roll, 'ccb');
-            // 故障情報を追加
-            (ccbRoll as any).breakdownNumber = breakdownNumber;
-            return ccbRoll;
+            // 故障判定用のCCBRollを作成（故障ナンバー付き）
+            const isSuccess = roll <= target;
+            const isSpecial = roll <= Math.ceil(target / 5);
+            const isCritical = roll <= 5;
+            const isFumble = roll >= 96;
+            
+            return new CCBRoll(
+                `ccb(${breakdownNumber})<=${target}`,
+                [roll],
+                roll,
+                target,
+                isSuccess,
+                isSpecial && isSuccess,
+                isCritical && isSuccess,
+                isFumble && !isSuccess,
+                breakdownNumber // 故障ナンバーを設定
+            );
         }
         
         // cc<=50 または ccb<=50 のような形式の場合
@@ -98,7 +110,8 @@ export class CoCDiceService {
             bothSuccess,
             false, // スペシャルは適用しない
             bothCritical,
-            eitherFumble
+            eitherFumble,
+            undefined // CBRには故障ナンバーなし
         );
     }
 

--- a/src/domain/services/dice/DiceServiceFactory.ts
+++ b/src/domain/services/dice/DiceServiceFactory.ts
@@ -5,10 +5,39 @@ import { StandardDiceService } from './StandardDiceService';
 import { CoCDiceService } from './CoCDiceService';
 import { SpecialDiceService } from './SpecialDiceService';
 
+/**
+ * DiceServiceFactory - シングルトンパターンによる最適化
+ * インスタンス生成コストを削減し、メモリ使用量を最適化
+ */
 export class DiceServiceFactory implements IDiceService {
-    private standardDiceService = new StandardDiceService();
-    private cocDiceService = new CoCDiceService();
-    private specialDiceService = new SpecialDiceService();
+    private static instance: DiceServiceFactory;
+    private readonly standardDiceService: StandardDiceService;
+    private readonly cocDiceService: CoCDiceService;
+    private readonly specialDiceService: SpecialDiceService;
+
+    private constructor() {
+        this.standardDiceService = new StandardDiceService();
+        this.cocDiceService = new CoCDiceService();
+        this.specialDiceService = new SpecialDiceService();
+    }
+
+    /**
+     * DiceServiceFactoryのシングルトンインスタンスを取得
+     * @returns DiceServiceFactoryインスタンス
+     */
+    static getInstance(): DiceServiceFactory {
+        if (!DiceServiceFactory.instance) {
+            DiceServiceFactory.instance = new DiceServiceFactory();
+        }
+        return DiceServiceFactory.instance;
+    }
+
+    /**
+     * テスト用のインスタンスクリア
+     */
+    static clearInstance(): void {
+        DiceServiceFactory.instance = undefined as any;
+    }
 
     roll(expression: DiceExpression): DiceRoll {
         const expr = expression.getTargetExpression();

--- a/src/infrastructure/commands/handlers/RollCommandHandler.ts
+++ b/src/infrastructure/commands/handlers/RollCommandHandler.ts
@@ -4,6 +4,11 @@ import { RollDiceUseCase } from '../../../application/use-cases/dice/RollDiceUse
 import { DiceService } from '../../../domain/services/DiceService';
 import { DiceEmbedFormatter } from '../../../presentation/formatters/DiceEmbedFormatter';
 
+/**
+ * ダイスロールコマンドハンドラー
+ * 基本的なダイス記法（1d6, 2d10+5など）をサポート
+ */
+
 export class RollCommandHandler implements Command {
     private readonly rollDiceUseCase: RollDiceUseCase;
     private readonly formatter: DiceEmbedFormatter;

--- a/src/infrastructure/commands/handlers/RollCommandHandler.ts
+++ b/src/infrastructure/commands/handlers/RollCommandHandler.ts
@@ -3,6 +3,7 @@ import { Command } from '../../../interfaces/Command';
 import { RollDiceUseCase } from '../../../application/use-cases/dice/RollDiceUseCase';
 import { DiceService } from '../../../domain/services/DiceService';
 import { DiceEmbedFormatter } from '../../../presentation/formatters/DiceEmbedFormatter';
+import { DiceSystemError, InvalidExpressionError } from '../../../shared/errors/DiceSystemError';
 
 /**
  * ダイスロールコマンドハンドラー
@@ -23,7 +24,8 @@ export class RollCommandHandler implements Command {
         ) as SlashCommandBuilder;
 
     constructor() {
-        const diceService = new DiceService();
+        // シングルトンパターンによる最適化
+        const diceService = new DiceService(); // DiceService内部でシングルトンファクトリを使用
         this.rollDiceUseCase = new RollDiceUseCase(diceService);
         this.formatter = new DiceEmbedFormatter();
     }
@@ -39,18 +41,36 @@ export class RollCommandHandler implements Command {
             });
 
             const embed = this.formatter.formatResponse(response, interaction);
-            
             await interaction.reply({ embeds: [embed] });
             
+            // 成功ログ（簡潔に）
             console.log(
                 `${interaction.guildId} ${interaction.user.username} ${expression} ${response.rolls.map(r => r.result).join(' ')}`
             );
+            
         } catch (error) {
+            // ユーザーフレンドリーなエラーメッセージ
+            let userMessage = 'ダイスロールの処理中にエラーが発生しました。';
+            
+            if (error instanceof InvalidExpressionError) {
+                userMessage = `無効なダイス式です: ${error.expression}\n詳細: ${error.message}`;
+            } else if (error instanceof DiceSystemError) {
+                userMessage = `ダイスシステムエラー: ${error.message}`;
+            }
+            
             await interaction.reply({
-                content: 'ダイスロールの処理中にエラーが発生しました。',
+                content: userMessage,
                 ephemeral: true
             });
-            console.error('Dice roll error:', error);
+            
+            // 詳細ログはコンソールに出力（デバッグ用）
+            console.error('Dice roll error:', {
+                error: error instanceof Error ? error.message : String(error),
+                expression,
+                userId: interaction.user.id,
+                guildId: interaction.guildId,
+                stack: error instanceof Error ? error.stack : undefined
+            });
         }
     }
 }

--- a/src/infrastructure/commands/legacy/DiceRollHandler.ts
+++ b/src/infrastructure/commands/legacy/DiceRollHandler.ts
@@ -4,13 +4,15 @@ import { DiceService } from '../../../domain/services/DiceService';
 import { DiceEmbedFormatter } from '../../../presentation/formatters/DiceEmbedFormatter';
 import { convertFullWidthToHalfWidth } from '../../../shared/utils/stringUtils';
 import { DiceCommandValidator } from './validation/diceCommandValidator';
+import { DiceSystemError, InvalidExpressionError } from '../../../shared/errors/DiceSystemError';
 
 export class DiceRollHandler {
     private readonly rollDiceUseCase: RollDiceUseCase;
     private readonly formatter: DiceEmbedFormatter;
 
     constructor() {
-        const diceService = new DiceService();
+        // シングルトンパターンによる最適化
+        const diceService = new DiceService(); // DiceService内部でシングルトンファクトリを使用
         this.rollDiceUseCase = new RollDiceUseCase(diceService);
         this.formatter = new DiceEmbedFormatter();
     }
@@ -50,12 +52,42 @@ export class DiceRollHandler {
             
             await message.reply({ embeds: [embedWithFullExpression] });
             
+            // 成功ログ（型安全に）
             console.log(
-                `${message.guildId} ${message.author.username} ${content} ${response.rolls.map((r: any) => r.result).join(' ')}`
+                `${message.guildId} ${message.author.username} ${content} ${response.rolls.map(r => r.result).join(' ')}`
             );
+            
         } catch (error) {
-            // Silently fail for classic commands
-            console.error('Classic dice roll error:', error);
+            // メッセージベースのダイスロールは控えめなエラー表示
+            if (error instanceof InvalidExpressionError) {
+                // 無効な式の場合は静かに無視（他のメッセージと混同を避けるため）
+                console.warn('Invalid dice expression (ignored):', error.expression);
+                return;
+            }
+            
+            if (error instanceof DiceSystemError) {
+                // システムエラーの場合はリアクションで通知
+                try {
+                    await message.react('❌');
+                } catch (reactionError) {
+                    // リアクション失敗時は無視
+                }
+                console.error('Dice system error:', {
+                    error: error.message,
+                    expression: content,
+                    userId: message.author.id,
+                    guildId: message.guildId
+                });
+                return;
+            }
+            
+            // その他のエラーはログのみ（クラシックコマンドは静かに失敗）
+            console.error('Classic dice roll error:', {
+                error: error instanceof Error ? error.message : String(error),
+                expression: content,
+                userId: message.author.id,
+                guildId: message.guildId
+            });
         }
     }
 }

--- a/src/shared/errors/DiceSystemError.ts
+++ b/src/shared/errors/DiceSystemError.ts
@@ -1,0 +1,54 @@
+/**
+ * ダイスシステム専用のエラークラス群
+ * より詳細でユーザーフレンドリーなエラーハンドリングを提供
+ */
+
+/**
+ * ダイスシステムの基底エラークラス
+ */
+export class DiceSystemError extends Error {
+    constructor(
+        message: string,
+        public readonly code: string,
+        public readonly expression?: string
+    ) {
+        super(message);
+        this.name = 'DiceSystemError';
+    }
+}
+
+/**
+ * 無効なダイス式エラー
+ */
+export class InvalidExpressionError extends DiceSystemError {
+    constructor(expression: string, details: string) {
+        super(`Invalid dice expression: ${details}`, 'INVALID_EXPRESSION', expression);
+    }
+}
+
+/**
+ * 数式評価エラー
+ */
+export class MathEvaluationError extends DiceSystemError {
+    constructor(expression: string, details: string) {
+        super(`Math evaluation failed: ${details}`, 'MATH_EVALUATION_ERROR', expression);
+    }
+}
+
+/**
+ * ダイス値範囲エラー
+ */
+export class DiceRangeError extends DiceSystemError {
+    constructor(expression: string, details: string) {
+        super(`Dice range error: ${details}`, 'DICE_RANGE_ERROR', expression);
+    }
+}
+
+/**
+ * セキュリティエラー（不正な文字など）
+ */
+export class DiceSecurityError extends DiceSystemError {
+    constructor(expression: string, details: string) {
+        super(`Security violation: ${details}`, 'DICE_SECURITY_ERROR', expression);
+    }
+}


### PR DESCRIPTION
@coderabbitai このファイルの変更に加えて、関連する以下のファイルも包括的にレビューしてください：

## 🔗 関連ファイル

### スラッシュコマンド系
- `src/infrastructure/commands/handlers/RollCommandHandler.ts` - /rollコマンドのハンドラー
- `src/infrastructure/commands/roll-command.ts` - rollコマンドエクスポート

### メッセージベースダイスロール系（重要）
- `src/infrastructure/commands/legacy/DiceRollHandler.ts` - メッセージ直接入力処理（1d100等）
- `src/infrastructure/commands/legacy/classicDiceRoll.ts` - クラシックダイス機能エントリ
- `src/infrastructure/commands/legacy/validation/diceCommandValidator.ts` - ダイス記法検証
- `src/adapters/discord/DiscordAdapter.ts` - メッセージハンドリング統合

### 業務ロジック・ドメイン層
- `src/application/use-cases/dice/RollDiceUseCase.ts` - ダイス業務ロジック
- `src/domain/services/DiceService.ts` - ダイスサービスのメインエントリ
- `src/domain/services/dice/DiceServiceFactory.ts` - ダイス種別の判定・振り分け
- `src/domain/services/dice/StandardDiceService.ts` - 標準ダイス処理
- `src/domain/services/dice/CoCDiceService.ts` - CoC専用ダイス処理
- `src/domain/entities/DiceRoll.ts` - 基本ダイスロールエンティティ
- `src/domain/entities/CoCDiceRoll.ts` - CoC専用ダイスロールエンティティ
- `src/domain/value-objects/DiceExpression.ts` - ダイス記法解析

### 表示・ユーティリティ
- `src/presentation/formatters/DiceEmbedFormatter.ts` - ダイス結果表示フォーマット
- `src/domain/utils/mathParser.ts` - 数式評価エンジン
- `src/shared/utils/stringUtils.ts` - 全角半角変換

## 📋 レビュー観点

### **アーキテクチャ整合性**
- スラッシュコマンド(/roll) vs メッセージ直接入力(1d100) の二重実装
- 共通のUseCase・Service層への適切な集約
- レガシー機能とモダン機能の統合状況

### **型安全性** 
- TypeScript型定義の一貫性と厳密性
- `any`型の使用状況と改善余地
- DiceRoll系エンティティの型階層最適化

### **エラーハンドリング**
- ダイス記法解析時の例外処理（両方式で統一されているか）
- ユーザーフレンドリーなエラーメッセージ
- 不正入力に対する適切な対応

### **パフォーマンス**
- DiceServiceの重複インスタンス化問題
- DiceServiceFactoryの最適化余地
- 数式評価処理の効率性

### **セキュリティ**
- mathParser.tsの数式評価安全性（任意コード実行防止）
- メッセージ入力のサニタイゼーション
- 全角半角変換処理の安全性

## 💡 特に注目してほしい改善ポイント

1. **二重実装の統一** - RollCommandHandler vs DiceRollHandler の共通化
2. **DiceService インスタンス管理** - シングルトンパターン適用
3. **型キャスト安全性** - `any`型や危険な型変換の検出
4. **mathParser セキュリティ** - eval()を使わない安全な数式評価
5. **メッセージ vs スラッシュコマンド** - 機能格差や重複の解消
6. **バリデーション統一** - DiceCommandValidator の活用状況

## 🎮 動作パターン

1. **スラッシュコマンド**: `/roll 1d100` → RollCommandHandler
2. **メッセージ直接**: `1d100` → DiscordAdapter.handleMessage → DiceRollHandler

この2つのルートが同じ品質・機能を提供できているか、統合の余地があるかを重点的に確認してください。

statusコマンドで実施した型安全性・パフォーマンス改善と同レベルの品質向上を目指しています。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - CCB形式のダイスロールを正式サポート。結果のDTO変換を拡充し、内訳番号（breakdown）の取得に対応。対応ゲーム（例：CCB/CoC/FA）での結果表示精度が向上。
- ドキュメント
  - ロールコマンドの説明コメントを追加。
- テスト
  - CCBロールの内訳取得をgetterに合わせて更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->