### PR TITLE
feat: ユーザー/サーバー単位のBAN機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ npm-debug.log*
 Thumbs.db 
 
 data/schedules.json
+# 実行時データ（BAN情報はサーバーごとに持つ）
+data/bans.json

--- a/src/adapters/discord/DiscordAdapter.ts
+++ b/src/adapters/discord/DiscordAdapter.ts
@@ -5,11 +5,14 @@ import { diceRoll } from '../../infrastructure/services/dice/classicDiceRoll';
 import { createErrorMessage } from '../../presentation/discord/builders/messages';
 import { WebSocketServer } from '../../infrastructure/websocket/WebSocketServer';
 import { MessageProcessor } from '../../infrastructure/services/MessageProcessor';
+import { banService } from '../../infrastructure/services/BanService';
 
 import * as fs from 'fs';
 import * as path from 'path';
 
 export class DiscordAdapter {
+    /** bot運営者(OWNER_ID)のみが実行できるメッセージコマンド */
+    private static readonly OWNER_ONLY_COMMANDS = new Set(['ban', 'unban', 'bans']);
     private prefix = '/#';
     private commands: Map<string, Command> = new Map();
     private adminCommands: Map<string, (message: Message, guildId: string) => Promise<void>> = new Map();
@@ -99,6 +102,14 @@ export class DiscordAdapter {
 
     private setupInteractionHandler() {
         this.client.on('interactionCreate', async interaction => {
+            // BANチェック: 対象ユーザー/サーバーは全機能を無言でブロック（運営者は除外）
+            if (
+                interaction.user.id !== process.env.OWNER_ID &&
+                banService.isBlocked(interaction.user.id, interaction.guildId)
+            ) {
+                return;
+            }
+
             if (interaction.isAutocomplete()) {
                 const command = this.commands.get(interaction.commandName);
                 if (command && 'autocomplete' in command && typeof (command as any).autocomplete === 'function') {
@@ -214,6 +225,14 @@ export class DiscordAdapter {
     }
 
     async handleMessage(message: Message) {
+        // BANチェック: 対象ユーザー/サーバーは全機能を無言でブロック（運営者は除外）
+        if (
+            message.author.id !== process.env.OWNER_ID &&
+            banService.isBlocked(message.author.id, message.guild?.id)
+        ) {
+            return;
+        }
+
         // 特別なメッセージパターンをチェック
         const processed = await MessageProcessor.processMessage(message);
         if (processed) {
@@ -233,6 +252,14 @@ export class DiscordAdapter {
 
         const adminCommand = this.adminCommands.get(command);
         if (adminCommand) {
+            // BAN管理コマンドはbot運営者のみ。権限が無ければ無言で無視
+            if (DiscordAdapter.OWNER_ONLY_COMMANDS.has(command)) {
+                if (message.author.id !== process.env.OWNER_ID) {
+                    return;
+                }
+                await adminCommand(message, guildId);
+                return;
+            }
             // 管理者権限を持っているか確認
             if (!message.member?.permissions.has('Administrator') && message.guild?.ownerId !== message.author.id) {
                 await message.reply(

--- a/src/infrastructure/commands/admin/ban.ts
+++ b/src/infrastructure/commands/admin/ban.ts
@@ -1,0 +1,44 @@
+import { Message } from 'discord.js';
+import { createErrorMessage, createSuccessMessage } from '../../../presentation/discord/builders/messages';
+import { banService } from '../../services/BanService';
+
+const USAGE = '使い方: `/#ban user <ユーザーID> [理由]` または `/#ban server <サーバーID> [理由]`';
+const SNOWFLAKE = /^\d{17,20}$/;
+
+export async function execute(message: Message, _guildId: string) {
+    const parts = message.content.trim().split(/\s+/);
+    const type = parts[1]?.toLowerCase();
+    const targetId = parts[2];
+    const reason = parts.slice(3).join(' ') || undefined;
+
+    if ((type !== 'user' && type !== 'server') || !targetId) {
+        await message.reply(createErrorMessage(message, 'BAN FAILED', USAGE));
+        return;
+    }
+
+    if (!SNOWFLAKE.test(targetId)) {
+        await message.reply(createErrorMessage(message, 'BAN FAILED', 'IDの形式が不正です（17〜20桁の数値）'));
+        return;
+    }
+
+    if (type === 'user') {
+        const added = banService.banUser(targetId, message.author.id, reason);
+        if (!added) {
+            await message.reply(createErrorMessage(message, 'BAN FAILED', `ユーザー \`${targetId}\` は既にBANされています`));
+            return;
+        }
+        await message.reply(
+            createSuccessMessage(message, 'USER BANNED', `ユーザー \`${targetId}\` を全サーバーでブロックしました${reason ? `\n理由: ${reason}` : ''}`)
+        );
+        return;
+    }
+
+    const added = banService.banServer(targetId, message.author.id, reason);
+    if (!added) {
+        await message.reply(createErrorMessage(message, 'BAN FAILED', `サーバー \`${targetId}\` は既にBANされています`));
+        return;
+    }
+    await message.reply(
+        createSuccessMessage(message, 'SERVER BANNED', `サーバー \`${targetId}\` 内の全機能をブロックしました${reason ? `\n理由: ${reason}` : ''}`)
+    );
+}

--- a/src/infrastructure/commands/admin/bans.ts
+++ b/src/infrastructure/commands/admin/bans.ts
@@ -1,0 +1,18 @@
+import { Message } from 'discord.js';
+import { createInfoMessage } from '../../../presentation/discord/builders/messages';
+import { banService } from '../../services/BanService';
+
+export async function execute(message: Message, _guildId: string) {
+    const users = banService.listUsers();
+    const servers = banService.listServers();
+
+    const fmt = (entry: { id: string; reason?: string }) =>
+        `\`${entry.id}\`${entry.reason ? ` — ${entry.reason}` : ''}`;
+
+    const userList = users.length ? users.map(fmt).join('\n') : 'なし';
+    const serverList = servers.length ? servers.map(fmt).join('\n') : 'なし';
+
+    await message.reply(
+        createInfoMessage(message, 'BAN LIST', `**ユーザー (${users.length})**\n${userList}\n\n**サーバー (${servers.length})**\n${serverList}`)
+    );
+}

--- a/src/infrastructure/commands/admin/unban.ts
+++ b/src/infrastructure/commands/admin/unban.ts
@@ -1,0 +1,39 @@
+import { Message } from 'discord.js';
+import { createErrorMessage, createSuccessMessage } from '../../../presentation/discord/builders/messages';
+import { banService } from '../../services/BanService';
+
+const USAGE = '使い方: `/#unban user <ユーザーID>` または `/#unban server <サーバーID>`';
+const SNOWFLAKE = /^\d{17,20}$/;
+
+export async function execute(message: Message, _guildId: string) {
+    const parts = message.content.trim().split(/\s+/);
+    const type = parts[1]?.toLowerCase();
+    const targetId = parts[2];
+
+    if ((type !== 'user' && type !== 'server') || !targetId) {
+        await message.reply(createErrorMessage(message, 'UNBAN FAILED', USAGE));
+        return;
+    }
+
+    if (!SNOWFLAKE.test(targetId)) {
+        await message.reply(createErrorMessage(message, 'UNBAN FAILED', 'IDの形式が不正です（17〜20桁の数値）'));
+        return;
+    }
+
+    if (type === 'user') {
+        const removed = banService.unbanUser(targetId);
+        if (!removed) {
+            await message.reply(createErrorMessage(message, 'UNBAN FAILED', `ユーザー \`${targetId}\` はBANされていません`));
+            return;
+        }
+        await message.reply(createSuccessMessage(message, 'USER UNBANNED', `ユーザー \`${targetId}\` のBANを解除しました`));
+        return;
+    }
+
+    const removed = banService.unbanServer(targetId);
+    if (!removed) {
+        await message.reply(createErrorMessage(message, 'UNBAN FAILED', `サーバー \`${targetId}\` はBANされていません`));
+        return;
+    }
+    await message.reply(createSuccessMessage(message, 'SERVER UNBANNED', `サーバー \`${targetId}\` のBANを解除しました`));
+}

--- a/src/infrastructure/services/BanService.ts
+++ b/src/infrastructure/services/BanService.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface BanRecord {
+    /** BANを実行した運営者のユーザーID */
+    bannedBy: string;
+    /** 理由（任意） */
+    reason?: string;
+    /** ISO 8601 形式のBAN日時 */
+    bannedAt: string;
+}
+
+interface BanData {
+    /** グローバルBANされたユーザー（どのサーバーでもbotを使えない） */
+    users: Record<string, BanRecord>;
+    /** BANされたサーバー（そのサーバー内では誰もbotを使えない） */
+    servers: Record<string, BanRecord>;
+}
+
+/**
+ * ユーザー / サーバー単位の全機能ブロック（BAN）を管理する。
+ * data/bans.json に永続化し、アプリ再起動後も状態を保持する。
+ */
+export class BanService {
+    private readonly dataFile: string;
+    private data: BanData = { users: {}, servers: {} };
+
+    constructor() {
+        this.dataFile = path.join(process.cwd(), 'data', 'bans.json');
+
+        const dataDir = path.dirname(this.dataFile);
+        if (!fs.existsSync(dataDir)) {
+            fs.mkdirSync(dataDir, { recursive: true });
+        }
+
+        this.load();
+    }
+
+    private load(): void {
+        if (!fs.existsSync(this.dataFile)) {
+            return;
+        }
+        try {
+            const parsed = JSON.parse(fs.readFileSync(this.dataFile, 'utf8'));
+            this.data = {
+                users: parsed.users ?? {},
+                servers: parsed.servers ?? {},
+            };
+            const userCount = Object.keys(this.data.users).length;
+            const serverCount = Object.keys(this.data.servers).length;
+            console.log(`[Ban] BAN情報を読み込みました (users: ${userCount}, servers: ${serverCount})`);
+        } catch (error) {
+            console.error('[Ban] BAN情報の読み込みに失敗:', error);
+        }
+    }
+
+    private save(): void {
+        fs.writeFileSync(this.dataFile, JSON.stringify(this.data, null, 2));
+    }
+
+    isUserBanned(userId: string): boolean {
+        return userId in this.data.users;
+    }
+
+    isServerBanned(guildId: string | null | undefined): boolean {
+        if (!guildId) return false;
+        return guildId in this.data.servers;
+    }
+
+    /** ユーザーがグローバルBAN、またはサーバーがBANされていればtrue */
+    isBlocked(userId: string, guildId: string | null | undefined): boolean {
+        return this.isUserBanned(userId) || this.isServerBanned(guildId);
+    }
+
+    /** 既にBAN済みならfalse、新規にBANしたらtrueを返す */
+    banUser(userId: string, bannedBy: string, reason?: string): boolean {
+        if (this.isUserBanned(userId)) return false;
+        this.data.users[userId] = { bannedBy, reason, bannedAt: new Date().toISOString() };
+        this.save();
+        return true;
+    }
+
+    banServer(guildId: string, bannedBy: string, reason?: string): boolean {
+        if (this.isServerBanned(guildId)) return false;
+        this.data.servers[guildId] = { bannedBy, reason, bannedAt: new Date().toISOString() };
+        this.save();
+        return true;
+    }
+
+    /** BANされていなければfalse、解除したらtrueを返す */
+    unbanUser(userId: string): boolean {
+        if (!this.isUserBanned(userId)) return false;
+        delete this.data.users[userId];
+        this.save();
+        return true;
+    }
+
+    unbanServer(guildId: string): boolean {
+        if (!this.isServerBanned(guildId)) return false;
+        delete this.data.servers[guildId];
+        this.save();
+        return true;
+    }
+
+    listUsers(): Array<{ id: string } & BanRecord> {
+        return Object.entries(this.data.users).map(([id, record]) => ({ id, ...record }));
+    }
+
+    listServers(): Array<{ id: string } & BanRecord> {
+        return Object.entries(this.data.servers).map(([id, record]) => ({ id, ...record }));
+    }
+}
+
+/** アプリ全体で共有するシングルトン */
+export const banService = new BanService();


### PR DESCRIPTION
## 概要
bot運営者(`OWNER_ID`)のみが操作できる、ユーザー/サーバー単位の全機能ブロック(BAN)機能。

## 仕様
- **ユーザーBAN**: 対象ユーザーを全サーバーでブロック（グローバル）
- **サーバーBAN**: 対象サーバー内の全員をブロック。※そのサーバーにいるユーザーでも、BANされていない別サーバーでは通常通り使える
- ブロック対象は スラッシュ/ボタン/セレクト/モーダル/オートコンプリート/メッセージコマンド/ダイスロール を**無言で無視**
- **運営者は常にブロック対象外**（BANされたサーバー内でも解除コマンドを実行可能）
- BAN情報は `data/bans.json` に永続化（gitignore対象。再起動後も保持）

## コマンド（メッセージコマンド `/#`、OWNER_IDのみ）
- `/#ban user <ユーザーID> [理由]`
- `/#ban server <サーバーID> [理由]`
- `/#unban user|server <ID>`
- `/#bans` 一覧表示

## デプロイ時の注意
- `.env` に `OWNER_ID`（運営者のDiscordユーザーID）の設定が**必須**。未設定だと誰もBAN系コマンドを使えない
- `dist/` 反映のため要ビルド

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * BAN管理に対応し、ユーザー・サーバー単位でのBAN登録、解除、一覧確認ができるようになりました。
  * 管理者向けにBAN関連コマンドが追加され、対象指定や理由付きで操作できます。

* **バグ修正**
  * BAN対象のユーザーやサーバーからの操作をブロックし、対象外の応答を防ぐようになりました。
  * 管理者専用コマンドは、権限のない操作を静かに無視するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->